### PR TITLE
Catch copy exception and display image url instead

### DIFF
--- a/lib/imgurr/command.rb
+++ b/lib/imgurr/command.rb
@@ -132,7 +132,8 @@ module Imgurr
         if success
           response = "![#{options[:title].nil? ? 'Screenshot' : options[:title]}](#{response})" if options[:markdown]
           response = build_HTML_response(response) if options[:html]
-          puts "Copied #{Platform.copy(response)} to clipboard"
+          copy_succeeded = Platform.copy(response)
+          puts copy_succeeded ? "Copied #{response} to clipboard" : "Image url: #{response}"
         end
         storage.save
       end

--- a/lib/imgurr/platform.rb
+++ b/lib/imgurr/platform.rb
@@ -73,10 +73,14 @@ module Imgurr
       # Public: copies a given URL value to the clipboard. This method is
       # designed to handle multiple platforms.
       #
-      # Returns nothing
+      # Returns success of command
       def copy(url)
-        IO.popen(copy_command,"w") {|cc|  cc.write(url)}
-        url
+        begin
+          IO.popen(copy_command,"w") {|cc| cc.write(url)}
+          true
+        rescue
+          false
+        end
       end
 
       # Public: returns the command used to capture a screenshot


### PR DESCRIPTION
Resolves #12 

Other solution was to `mkmf` module and the [`find_executable`](http://ruby-doc.org/stdlib-2.3.0/libdoc/mkmf/rdoc/MakeMakefile.html#method-i-find_executable) method to detect if the system responds to the command but I'd rather not use the `mkmf` module for this. Instead just return the success of the command with a boolean and handle the output appropriately.  
